### PR TITLE
Adds the lab 1 module

### DIFF
--- a/data/lab/1/meta.json
+++ b/data/lab/1/meta.json
@@ -1,0 +1,12 @@
+{
+  "id": 1,
+  "submoduleNumber": 1,
+  "submoduleName": "Modifying Topology",
+  "objective": "Add and remove devices and their connections.",
+  "tasks": [
+    "Add a Host (h3)",
+    "Attach h3 to s2",
+    "Detach h3 from s2",
+    "Remove h2"
+  ]
+}


### PR DESCRIPTION
This enables `toynet` to not statically use directions for labs anymore. Also enables us to add more lab content.