### PR TITLE
Adds topology id to the lab

### DIFF
--- a/data/lab/1/meta.json
+++ b/data/lab/1/meta.json
@@ -1,6 +1,7 @@
 {
   "id": 1,
   "submoduleNumber": 1,
+  "topology": 1,
   "submoduleName": "Modifying Topology",
   "objective": "Add and remove devices and their connections.",
   "tasks": [


### PR DESCRIPTION
Currently, there is no way to identify which topology should be used for a specific lab. This PR adds the `topology` field to the lab data which identifies which topology should be used.